### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ $ git clone https://github.com/ohucode/ohucode
 $ cd ohucode
 $ mkdir checkouts
 $ git clone https://github.com/hatemogi/misaeng checkouts/misaeng
+$ cd checkouts/misaeng
+$ lein install
+$ cd ../..
+$ lein deps
 ```
 
 ### 7. DB 유저, 데이터베이스 생성. JDBC 연결설정파일 준비


### PR DESCRIPTION
leiningen 2.6.1에서 미생을 lein install 하지 않았을 때 다음의 오류를 만났습니다.

> Could not find artifact misaeng:misaeng:jar:0.1.0 in central (https://repo1.maven.org/maven2/)
> Could not find artifact misaeng:misaeng:jar:0.1.0 in clojars (https://clojars.org/repo/)
> This could be due to a typo in :dependencies or network issues.
> If you are behind a proxy, try setting the 'http_proxy' environment variable.

혹시 checkouts에 있는 프로젝트들을 자동으로 빌드해주는 플러그인들이 있다면 그것들의 설치에 대한 내용이 있으면 더 좋겠습니다.
